### PR TITLE
Add shelf life lookup and spoilage visualizations

### DIFF
--- a/backend/data/shelf_life.csv
+++ b/backend/data/shelf_life.csv
@@ -1,0 +1,16 @@
+item,category,shelf_life_days
+apple,fruit,30
+banana,fruit,7
+spinach,vegetable,5
+milk,dairy,7
+rice,grains,365
+chicken,meat,2
+beef,meat,3
+lettuce,vegetable,7
+bread,grains,5
+tomato,fruit,10
+potato,vegetable,90
+cheese,dairy,21
+yogurt,dairy,14
+cabbage,vegetable,14
+orange,fruit,30

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,3 +18,6 @@ typing_extensions==4.14.1
 urllib3==2.5.0
 uvicorn==0.35.0
 scikit-learn==1.7.1
+pandas==2.2.2
+joblib==1.4.2
+rapidfuzz==3.6.1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,9 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.3.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,8 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { Bar } from "react-chartjs-2";
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Tooltip, Legend } from "chart.js";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
 function App() {
   const [item, setItem] = useState("");
@@ -8,6 +12,9 @@ function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [recommendation, setRecommendation] = useState(null);
+  const [shelfItem, setShelfItem] = useState("");
+  const [shelfResult, setShelfResult] = useState(null);
+  const [topSpoiled, setTopSpoiled] = useState([]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -49,9 +56,75 @@ function App() {
     }
   };
 
+  const handleShelfSearch = async () => {
+    if (!shelfItem.trim()) return;
+    setError(null);
+    try {
+      const res = await fetch(
+        `http://127.0.0.1:8000/shelf_life?item=${encodeURIComponent(shelfItem)}`
+      );
+      if (!res.ok) {
+        throw new Error("Failed to fetch shelf life");
+      }
+      const data = await res.json();
+      setShelfResult(data);
+    } catch (err) {
+      setError(err.message);
+      setShelfResult(null);
+    }
+  };
+
+  const fetchTopSpoiled = async () => {
+    try {
+      const res = await fetch("http://127.0.0.1:8000/top_spoiled");
+      const data = await res.json();
+      setTopSpoiled(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchTopSpoiled();
+  }, []);
+
+  useEffect(() => {
+    if (recommendation) {
+      fetchTopSpoiled();
+    }
+  }, [recommendation]);
+
   return (
     <div style={{ maxWidth: 600, margin: "auto", fontFamily: "Arial, sans-serif", padding: 20 }}>
       <h1>Smart Inventory Spoilage Predictor</h1>
+
+      <div style={{ marginBottom: 20 }}>
+        <h2>Lookup Shelf Life</h2>
+        <input
+          type="text"
+          value={shelfItem}
+          onChange={(e) => setShelfItem(e.target.value)}
+          placeholder="e.g. Milk"
+          style={{ width: "70%", padding: 8 }}
+        />
+        <button
+          type="button"
+          onClick={handleShelfSearch}
+          style={{ padding: "8px 12px", marginLeft: 10 }}
+        >
+          Search
+        </button>
+        {shelfResult && (
+          <div style={{ marginTop: 10 }}>
+            <p>
+              Average shelf life for <strong>{shelfResult.item}</strong>: {shelfResult.avg_shelf_life} days
+            </p>
+            {topSpoiled.some(
+              (i) => i.item.toLowerCase() === shelfResult.item.toLowerCase()
+            ) && <p style={{ color: "red" }}>This item is among the top spoiled items!</p>}
+          </div>
+        )}
+      </div>
 
       <form onSubmit={handleSubmit} style={{ marginBottom: 20 }}>
         <div style={{ marginBottom: 10 }}>
@@ -158,6 +231,29 @@ function App() {
           {recommendation.weather_explanation && (
             <p><em>{recommendation.weather_explanation}</em></p>
           )}
+        </div>
+      )}
+
+      {topSpoiled.length > 0 && (
+        <div style={{ marginTop: 30 }}>
+          <h2>Top Spoiled Items</h2>
+          <Bar
+            data={{
+              labels: topSpoiled.map((d) => d.item),
+              datasets: [
+                {
+                  label: "Loss %",
+                  data: topSpoiled.map((d) => d.loss_percentage),
+                  backgroundColor: "rgba(255,99,132,0.5)",
+                },
+              ],
+            }}
+            options={{
+              responsive: true,
+              plugins: { legend: { display: false } },
+              scales: { y: { beginAtZero: true } },
+            }}
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- load shelf-life data with fuzzy matching and expose `/shelf_life` and `/top_spoiled` endpoints
- track inventory risk predictions for top-spoiled chart
- add React UI for shelf-life lookup and spoilage bar chart

## Testing
- `pip install -r backend/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/chart.js)*
- `CI=true npm test` *(fails: Cannot find module 'react-chartjs-2')*

------
https://chatgpt.com/codex/tasks/task_e_689dd0f0c614832f967c73854b1b8e4f