### PR TITLE
feat: use configurable API URL

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:8000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,18 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Environment Variables
+
+Create a `.env` file in this directory and set the backend API endpoint:
+
+```
+REACT_APP_API_URL=http://localhost:8000
+```
+
+The above default targets a locally running backend. In production, override
+`REACT_APP_API_URL` with the URL of your deployed API before running `npm run build`
+or by configuring the environment variable in your hosting provider.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,8 +1,17 @@
 import React, { useState, useEffect } from "react";
 import { Bar } from "react-chartjs-2";
-import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Tooltip, Legend } from "chart.js";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000";
 
 function App() {
   const [item, setItem] = useState("");
@@ -29,7 +38,7 @@ function App() {
     setRecommendation(null);
 
     try {
-      const res = await fetch("http://127.0.0.1:8000/inventory", {
+      const res = await fetch(`${API_URL}/inventory`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -61,7 +70,7 @@ function App() {
     setError(null);
     try {
       const res = await fetch(
-        `http://127.0.0.1:8000/shelf_life?item=${encodeURIComponent(shelfItem)}`
+        `${API_URL}/shelf_life?item=${encodeURIComponent(shelfItem)}`
       );
       if (!res.ok) {
         throw new Error("Failed to fetch shelf life");
@@ -76,7 +85,7 @@ function App() {
 
   const fetchTopSpoiled = async () => {
     try {
-      const res = await fetch("http://127.0.0.1:8000/top_spoiled");
+      const res = await fetch(`${API_URL}/top_spoiled`);
       const data = await res.json();
       setTopSpoiled(data);
     } catch (err) {


### PR DESCRIPTION
## Summary
- use `REACT_APP_API_URL` to configure backend base URL
- document API URL configuration in README
- provide `.env.example` for local setup

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: No matching version found for react-chartjs-2@^5.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_689de54eeb04832fa8522fb6c6a4f873