### PR TITLE
Add spoilage charts and store management

### DIFF
--- a/backend/test_inventory.py
+++ b/backend/test_inventory.py
@@ -1,4 +1,4 @@
-from main import calculate_spoilage_risk
+from main import calculate_spoilage_risk, global_waste, model_info
 
 def test_low_risk():
     risk = calculate_spoilage_risk(avg_temp=22, humidity=50, chance_of_rain=10, month=5, category='frozen')
@@ -11,3 +11,14 @@ def test_moderate_risk():
 def test_high_risk():
     risk = calculate_spoilage_risk(avg_temp=32, humidity=80, chance_of_rain=80, month=8, category='vegetable')
     assert risk >= 6
+
+
+def test_global_waste():
+    data = global_waste()
+    assert isinstance(data, list) and len(data) > 0
+    assert 'commodity' in data[0]
+
+
+def test_model_info():
+    info = model_info()
+    assert info.get('model') == 'RandomForestRegressor'

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,38 +1,90 @@
-.App {
-  text-align: center;
+body {
+  margin: 0;
+  font-family: 'Poppins', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #0d1b2a;
+  color: #f5f5dc;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
+.card {
+  background: #1b263b;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  padding: 20px;
+  margin-bottom: 20px;
 }
 
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
+.field {
+  margin-bottom: 10px;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
 }
 
-.App-link {
-  color: #61dafb;
+button {
+  background-color: #e0a96d;
+  color: #0d1b2a;
+  border: none;
+  border-radius: 4px;
+  padding: 10px 20px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
 }
 
-@keyframes App-logo-spin {
+button:hover {
+  background-color: #c68b59;
+}
+
+.item-list {
+  list-style: none;
+  padding: 0;
+}
+
+.item-list li {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 8px;
+}
+
+.chart-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.chart-grid .card {
+  flex: 1;
+  min-width: 300px;
+}
+
+input,
+select {
+  background-color: #415a77;
+  color: #f5f5dc;
+  border: 1px solid #f5f5dc;
+  border-radius: 4px;
+  padding: 8px;
+}
+
+input::placeholder {
+  color: #e0e0e0;
+}
+
+.fade-in {
+  animation: fadeIn 0.5s ease-in;
+}
+
+@keyframes fadeIn {
   from {
-    transform: rotate(0deg);
+    opacity: 0;
+    transform: translateY(10px);
   }
   to {
-    transform: rotate(360deg);
+    opacity: 1;
+    transform: translateY(0);
   }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,15 +1,25 @@
 import React, { useState, useEffect } from "react";
-import { Bar } from "react-chartjs-2";
+import "./App.css";
+import { Bar, Pie } from "react-chartjs-2";
 import {
   Chart as ChartJS,
   CategoryScale,
   LinearScale,
   BarElement,
+  ArcElement,
   Tooltip,
   Legend,
 } from "chart.js";
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  ArcElement,
+  Tooltip,
+  Legend
+);
+ChartJS.defaults.color = "#F5F5DC";
 
 const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000";
 
@@ -23,7 +33,9 @@ function App() {
   const [recommendation, setRecommendation] = useState(null);
   const [shelfItem, setShelfItem] = useState("");
   const [shelfResult, setShelfResult] = useState(null);
-  const [topSpoiled, setTopSpoiled] = useState([]);
+  const [globalWaste, setGlobalWaste] = useState([]);
+  const [storeStats, setStoreStats] = useState([]);
+  const [modelInfo, setModelInfo] = useState(null);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -83,31 +95,81 @@ function App() {
     }
   };
 
-  const fetchTopSpoiled = async () => {
+  const fetchGlobalWaste = async () => {
     try {
-      const res = await fetch(`${API_URL}/top_spoiled`);
+      const res = await fetch(`${API_URL}/global_waste`);
       const data = await res.json();
-      setTopSpoiled(data);
+      setGlobalWaste(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const fetchModelInfo = async () => {
+    try {
+      const res = await fetch(`${API_URL}/model_info`);
+      const data = await res.json();
+      setModelInfo(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const fetchStoreStats = async (cityName) => {
+    try {
+      const res = await fetch(
+        `${API_URL}/store_spoiled?city=${encodeURIComponent(cityName)}`
+      );
+      const data = await res.json();
+      setStoreStats(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleDelete = async (itemName) => {
+    try {
+      await fetch(`${API_URL}/store_spoiled`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ city, item: itemName }),
+      });
+      fetchStoreStats(city);
     } catch (err) {
       console.error(err);
     }
   };
 
   useEffect(() => {
-    fetchTopSpoiled();
+    fetchGlobalWaste();
+    fetchModelInfo();
+    fetchStoreStats(city);
   }, []);
 
   useEffect(() => {
     if (recommendation) {
-      fetchTopSpoiled();
+      fetchStoreStats(city);
     }
-  }, [recommendation]);
+  }, [recommendation, city]);
+
+  useEffect(() => {
+    fetchStoreStats(city);
+  }, [city]);
 
   return (
-    <div style={{ maxWidth: 600, margin: "auto", fontFamily: "Arial, sans-serif", padding: 20 }}>
-      <h1>Smart Inventory Spoilage Predictor</h1>
+    <div className="container">
+      <h1 className="fade-in">Smart Inventory Spoilage Predictor</h1>
+      {modelInfo && (
+        <div className="card fade-in">
+          <h2>About the Model</h2>
+          <p>
+            We use a <strong>{modelInfo.model}</strong> to estimate spoilage.
+          </p>
+          <p>{modelInfo.details}</p>
+        </div>
+      )}
 
-      <div style={{ marginBottom: 20 }}>
+      <div className="card">
         <h2>Lookup Shelf Life</h2>
         <input
           type="text"
@@ -116,11 +178,7 @@ function App() {
           placeholder="e.g. Milk"
           style={{ width: "70%", padding: 8 }}
         />
-        <button
-          type="button"
-          onClick={handleShelfSearch}
-          style={{ padding: "8px 12px", marginLeft: 10 }}
-        >
+        <button type="button" onClick={handleShelfSearch}>
           Search
         </button>
         {shelfResult && (
@@ -128,33 +186,32 @@ function App() {
             <p>
               Average shelf life for <strong>{shelfResult.item}</strong>: {shelfResult.avg_shelf_life} days
             </p>
-            {topSpoiled.some(
-              (i) => i.item.toLowerCase() === shelfResult.item.toLowerCase()
-            ) && <p style={{ color: "red" }}>This item is among the top spoiled items!</p>}
+            {globalWaste.some(
+              (i) => i.commodity.toLowerCase() === shelfResult.item.toLowerCase()
+            ) && (
+              <p style={{ color: "red" }}>
+                This item is among the most wasted globally!
+              </p>
+            )}
           </div>
         )}
       </div>
 
-      <form onSubmit={handleSubmit} style={{ marginBottom: 20 }}>
-        <div style={{ marginBottom: 10 }}>
-          <label>Item Name:</label><br />
+      <form onSubmit={handleSubmit} className="card">
+        <div className="field">
+          <label>Item Name:</label>
           <input
             type="text"
             value={item}
             onChange={(e) => setItem(e.target.value)}
             placeholder="e.g. Rice, milled"
-            style={{ width: "100%", padding: 8 }}
             required
           />
         </div>
 
-        <div style={{ marginBottom: 10 }}>
-          <label>Category:</label><br />
-          <select
-            value={category}
-            onChange={(e) => setCategory(e.target.value)}
-            style={{ width: "100%", padding: 8 }}
-          >
+        <div className="field">
+          <label>Category:</label>
+          <select value={category} onChange={(e) => setCategory(e.target.value)}>
             <option value="vegetable">Vegetable</option>
             <option value="fruit">Fruit</option>
             <option value="dairy">Dairy</option>
@@ -166,60 +223,40 @@ function App() {
           </select>
         </div>
 
-        <div style={{ marginBottom: 10 }}>
-          <label>City:</label><br />
+        <div className="field">
+          <label>City:</label>
           <input
             type="text"
             value={city}
             onChange={(e) => setCity(e.target.value)}
             placeholder="e.g. Singapore"
-            style={{ width: "100%", padding: 8 }}
             required
           />
         </div>
 
-        <div style={{ marginBottom: 10 }}>
-          <label>Arrival Date:</label><br />
+        <div className="field">
+          <label>Arrival Date:</label>
           <input
             type="date"
             value={arrivalDate}
             onChange={(e) => setArrivalDate(e.target.value)}
-            style={{ width: "100%", padding: 8 }}
             required
           />
         </div>
 
-        <button
-          type="submit"
-          disabled={loading}
-          style={{
-            padding: "10px 20px",
-            backgroundColor: "#007bff",
-            color: "white",
-            border: "none",
-            cursor: loading ? "not-allowed" : "pointer",
-            width: "100%",
-          }}
-        >
+        <button type="submit" disabled={loading}>
           {loading ? "Calculating..." : "Get Recommendation"}
         </button>
       </form>
 
       {error && (
-        <div style={{ color: "red", marginBottom: 10 }}>
+        <div className="card" style={{ color: "red" }}>
           <strong>Error:</strong> {error}
         </div>
       )}
 
       {recommendation && (
-        <div
-          style={{
-            border: "1px solid #ccc",
-            borderRadius: 4,
-            padding: 15,
-            backgroundColor: "#f9f9f9",
-          }}
-        >
+        <div className="card fade-in">
           <h2>Recommendation</h2>
           <p>{recommendation.recommendation}</p>
           {recommendation.loss_percentage !== undefined && (
@@ -243,28 +280,65 @@ function App() {
         </div>
       )}
 
-      {topSpoiled.length > 0 && (
-        <div style={{ marginTop: 30 }}>
-          <h2>Top Spoiled Items</h2>
-          <Bar
-            data={{
-              labels: topSpoiled.map((d) => d.item),
-              datasets: [
-                {
-                  label: "Loss %",
-                  data: topSpoiled.map((d) => d.loss_percentage),
-                  backgroundColor: "rgba(255,99,132,0.5)",
-                },
-              ],
-            }}
-            options={{
-              responsive: true,
-              plugins: { legend: { display: false } },
-              scales: { y: { beginAtZero: true } },
-            }}
-          />
-        </div>
-      )}
+      <div className="chart-grid">
+        {globalWaste.length > 0 && (
+          <div className="card fade-in">
+            <h2>Global Food Wastage</h2>
+            <Pie
+              data={{
+                labels: globalWaste.map(
+                  (d) => `${d.commodity} (${d.country})`
+                ),
+                datasets: [
+                  {
+                    data: globalWaste.map((d) => d.loss_percentage),
+                    backgroundColor: [
+                      "#FF6384",
+                      "#36A2EB",
+                      "#FFCE56",
+                      "#4BC0C0",
+                      "#9966FF",
+                    ],
+                  },
+                ],
+              }}
+            />
+          </div>
+        )}
+
+        {storeStats.length > 0 && (
+          <div className="card fade-in">
+            <h2>{city} Store Items</h2>
+            <Bar
+              data={{
+                labels: storeStats.map((d) => d.item),
+                datasets: [
+                  {
+                    label: "Loss %",
+                    data: storeStats.map((d) => d.loss_percentage),
+                    backgroundColor: "rgba(75,192,192,0.5)",
+                  },
+                ],
+              }}
+              options={{
+                responsive: true,
+                plugins: { legend: { display: false } },
+                scales: { y: { beginAtZero: true } },
+              }}
+            />
+            <ul className="item-list">
+              {storeStats.map((s) => (
+                <li key={s.item}>
+                  <span>
+                    {s.item} ({s.loss_percentage.toFixed(1)}%)
+                  </span>
+                  <button onClick={() => handleDelete(s.item)}>Remove</button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Smart Inventory Spoilage Predictor/i);
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- Load global wastage data and expose `/global_waste` and `/model_info` endpoints
- Show global wastage pie chart, per-store spoilage chart with item removal, and display model details
- Apply dark blue theme with cream text and updated form styling

## Testing
- `pytest`
- `CI=true npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de824ef2c832fb9b26e89f8b05f31