### PR TITLE
Add animated global waste data transformation

### DIFF
--- a/backend/test_inventory.py
+++ b/backend/test_inventory.py
@@ -1,4 +1,9 @@
-from main import calculate_spoilage_risk, global_waste, model_info
+from main import (
+    calculate_spoilage_risk,
+    global_waste,
+    model_info,
+    calculate_global_waste_steps,
+)
 
 def test_low_risk():
     risk = calculate_spoilage_risk(avg_temp=22, humidity=50, chance_of_rain=10, month=5, category='frozen')
@@ -22,3 +27,9 @@ def test_global_waste():
 def test_model_info():
     info = model_info()
     assert info.get('model') == 'GradientBoostingRegressor'
+
+
+def test_global_waste_steps():
+    steps = calculate_global_waste_steps(limit=2)
+    assert steps[-1]["step"] == "top_waste_items"
+    assert len(steps[-1]["top"]) == 2

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -177,3 +177,13 @@ h1{
   font-size: 2rem;
   font-family: 'Fira Mono', monospace;
 }
+
+.animation-steps {
+  list-style: none;
+  padding: 0;
+  margin-top: 10px;
+}
+
+.animation-steps li {
+  margin-bottom: 8px;
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,6 +10,7 @@ import {
   Tooltip,
   Legend,
 } from "chart.js";
+import GlobalWasteSteps from "./GlobalWasteSteps";
 
 ChartJS.register(
   CategoryScale,
@@ -278,6 +279,8 @@ function App() {
           )}
         </div>
       )}
+
+      <GlobalWasteSteps />
 
         <div className="chart-grid">
           {globalWaste.length > 0 && (

--- a/frontend/src/GlobalWasteSteps.js
+++ b/frontend/src/GlobalWasteSteps.js
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+
+const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000";
+
+function GlobalWasteSteps() {
+  const [steps, setSteps] = useState([]);
+  const [running, setRunning] = useState(false);
+
+  const startAnimation = async () => {
+    setRunning(true);
+    try {
+      const res = await fetch(`${API_URL}/global_waste_steps`);
+      const data = await res.json();
+      setSteps([]);
+      data.forEach((step, idx) => {
+        setTimeout(() => {
+          setSteps((prev) => [...prev, step]);
+        }, idx * 1000);
+      });
+      setTimeout(() => setRunning(false), data.length * 1000);
+    } catch (err) {
+      console.error(err);
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="card">
+      <h2>Data Transformation</h2>
+      <button onClick={startAnimation} disabled={running}>
+        {running ? "Processing..." : "Show Transformation"}
+      </button>
+      <ul className="animation-steps">
+        {steps.map((s, i) => (
+          <li key={i}>
+            <strong>{s.step}</strong>: {s.description}
+            {s.top && (
+              <ul>
+                {s.top.map((t) => (
+                  <li key={t.commodity}>
+                    {t.commodity} ({t.loss_percentage.toFixed(1)}%)
+                  </li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default GlobalWasteSteps;


### PR DESCRIPTION
## Summary
- expose `/global_waste_steps` endpoint with step-by-step transformation of wastage data
- add React component to animate global waste processing for users
- style and test data transformation flow

## Testing
- `python -m pytest -q`
- `CI=true npm test -- --watchAll=false` *(fails: sh: 1: react-scripts: not found)*
- `npm install` *(fails: No matching version found for react-chartjs-2@^5.3.1)*
