### PR TITLE
Animate waste data processing and use full dataset

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -45,8 +45,7 @@ def train_global_model():
     df = WASTAGE_DF.copy()
     df["loss_percentage"] = pd.to_numeric(df["loss_percentage"], errors="coerce")
     df = df.dropna(subset=["loss_percentage", "commodity", "activity", "food_supply_stage"])
-    if len(df) > 5000:
-        df = df.sample(5000, random_state=42)
+    # Use the full dataset (~23k rows) for a more accurate model
     features = ["commodity", "activity", "food_supply_stage"]
     X = df[features]
     y = df["loss_percentage"]
@@ -85,6 +84,59 @@ GLOBAL_MODEL_INFO["conclusion"] = (
     + ", ".join(GLOBAL_MODEL_INFO["top_items"])
     + "."
 )
+
+
+def calculate_global_waste_steps(limit: int = 5):
+    """Return step-by-step transformation for global waste data."""
+    df = WASTAGE_DF.copy()
+    steps = []
+    steps.append({"step": "load_data", "description": f"Loaded {len(df)} rows", "rows": int(len(df))})
+    df["loss_percentage"] = pd.to_numeric(df["loss_percentage"], errors="coerce")
+    before = len(df)
+    df = df.dropna(subset=["loss_percentage", "commodity", "activity", "food_supply_stage"])
+    cleaned = len(df)
+    steps.append(
+        {
+            "step": "clean_data",
+            "description": f"Removed {before - cleaned} rows with missing values; {cleaned} rows remain",
+            "rows": int(cleaned),
+        }
+    )
+    # No sampling – process the entire dataset for accuracy
+    features = ["commodity", "activity", "food_supply_stage"]
+    X = df[features]
+    y = df["loss_percentage"]
+    pre = ColumnTransformer([("cat", OneHotEncoder(handle_unknown="ignore"), features)])
+    model = GradientBoostingRegressor(random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    pipe = Pipeline(steps=[("pre", pre), ("model", model)])
+    pipe.fit(X_train, y_train)
+    preds = pipe.predict(X_test)
+    accuracy = r2_score(y_test, preds)
+    steps.append({"step": "train_model", "description": f"Trained model with R^2={accuracy:.2f}"})
+    all_preds = pipe.predict(X)
+    df["predicted_loss"] = all_preds
+    top = (
+        df.groupby("commodity")["predicted_loss"]
+        .mean()
+        .sort_values(ascending=False)
+        .head(limit)
+        .reset_index()
+    )
+    steps.append(
+        {
+            "step": "top_waste_items",
+            "description": "Identified top wasted items globally",
+            "top": top.rename(columns={"predicted_loss": "loss_percentage"}).to_dict(orient="records"),
+        }
+    )
+    return steps
+
+
+@app.get("/global_waste_steps")
+def global_waste_steps(limit: int = 5):
+    """Return transformation steps for animation."""
+    return calculate_global_waste_steps(limit)
 
 # Load shelf life data from CSV and prepare fuzzy matching
 DATA_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "shelf_life.csv")

--- a/backend/test_inventory.py
+++ b/backend/test_inventory.py
@@ -1,4 +1,9 @@
-from main import calculate_spoilage_risk, global_waste, model_info
+from main import (
+    calculate_spoilage_risk,
+    global_waste,
+    model_info,
+    calculate_global_waste_steps,
+)
 
 def test_low_risk():
     risk = calculate_spoilage_risk(avg_temp=22, humidity=50, chance_of_rain=10, month=5, category='frozen')
@@ -22,3 +27,9 @@ def test_global_waste():
 def test_model_info():
     info = model_info()
     assert info.get('model') == 'GradientBoostingRegressor'
+
+
+def test_global_waste_steps():
+    steps = calculate_global_waste_steps(limit=2)
+    assert steps[-1]["step"] == "top_waste_items"
+    assert len(steps[-1]["top"]) == 2

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -177,3 +177,48 @@ h1{
   font-size: 2rem;
   font-family: 'Fira Mono', monospace;
 }
+
+.animation-steps {
+  list-style: none;
+  padding: 0;
+  margin-top: 10px;
+}
+
+.animation-steps li {
+  margin-bottom: 8px;
+}
+
+.progress-wrapper {
+  position: relative;
+  background: #415a77;
+  border-radius: 4px;
+  height: 6px;
+  margin-top: 4px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  background: #e0a96d;
+  height: 100%;
+  transition: width 0.2s linear;
+}
+
+.progress-label {
+  font-size: 0.75rem;
+  margin-left: 4px;
+}
+
+.loading-dots::after {
+  content: "";
+  display: inline-block;
+  width: 1em;
+  text-align: left;
+  animation: dots 1s steps(5, end) infinite;
+}
+
+@keyframes dots {
+  0%, 20% { content: ""; }
+  40% { content: "."; }
+  60% { content: ".."; }
+  80%, 100% { content: "..."; }
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,6 +10,7 @@ import {
   Tooltip,
   Legend,
 } from "chart.js";
+import GlobalWasteSteps from "./GlobalWasteSteps";
 
 ChartJS.register(
   CategoryScale,
@@ -36,6 +37,7 @@ function App() {
   const [globalWaste, setGlobalWaste] = useState([]);
   const [storeStats, setStoreStats] = useState([]);
   const [modelInfo, setModelInfo] = useState(null);
+  const [animTrigger, setAnimTrigger] = useState(0);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -70,6 +72,7 @@ function App() {
       const data = await res.json();
       setRecommendation(data);
       fetchModelInfo();
+      setAnimTrigger((t) => t + 1);
     } catch (err) {
       setError(err.message);
       setRecommendation(null);
@@ -278,6 +281,8 @@ function App() {
           )}
         </div>
       )}
+
+      <GlobalWasteSteps trigger={animTrigger} />
 
         <div className="chart-grid">
           {globalWaste.length > 0 && (

--- a/frontend/src/GlobalWasteSteps.js
+++ b/frontend/src/GlobalWasteSteps.js
@@ -1,0 +1,96 @@
+import React, { useState, useEffect } from "react";
+
+const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000";
+
+const Typewriter = ({ text }) => {
+  const [display, setDisplay] = useState("");
+  useEffect(() => {
+    setDisplay("");
+    let i = 0;
+    const interval = setInterval(() => {
+      setDisplay((prev) => prev + text.charAt(i));
+      i++;
+      if (i >= text.length) clearInterval(interval);
+    }, 25);
+    return () => clearInterval(interval);
+  }, [text]);
+  return <span>{display}</span>;
+};
+
+const Progress = ({ total }) => {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    let current = 0;
+    const inc = Math.max(1, Math.floor(total / 100));
+    const interval = setInterval(() => {
+      current += inc;
+      if (current >= total) {
+        current = total;
+        clearInterval(interval);
+      }
+      setCount(current);
+    }, 20);
+    return () => clearInterval(interval);
+  }, [total]);
+  const percent = (count / total) * 100;
+  return (
+    <div className="progress-wrapper">
+      <div className="progress-bar" style={{ width: `${percent}%` }} />
+      <span className="progress-label">{count}/{total}</span>
+    </div>
+  );
+};
+
+function GlobalWasteSteps({ trigger }) {
+  const [steps, setSteps] = useState([]);
+  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    if (!trigger) return;
+    startAnimation();
+  }, [trigger]);
+
+  const startAnimation = async () => {
+    setRunning(true);
+    try {
+      const res = await fetch(`${API_URL}/global_waste_steps`);
+      const data = await res.json();
+      setSteps([]);
+      data.forEach((step, idx) => {
+        setTimeout(() => {
+          setSteps((prev) => [...prev, step]);
+          if (idx === data.length - 1) setRunning(false);
+        }, idx * 1000);
+      });
+    } catch (err) {
+      console.error(err);
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="card">
+      <h2>Data Transformation</h2>
+      {running && <p className="loading-dots">Processing</p>}
+      <ul className="animation-steps">
+        {steps.map((s, i) => (
+          <li key={i}>
+            <strong>{s.step}</strong>: <Typewriter text={s.description} />
+            {s.rows && <Progress total={s.rows} />}
+            {s.top && (
+              <ul>
+                {s.top.map((t) => (
+                  <li key={t.commodity}>
+                    {t.commodity} ({t.loss_percentage.toFixed(1)}%)
+                  </li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default GlobalWasteSteps;


### PR DESCRIPTION
## Summary
- remove 5k-row sampling so global waste model trains on the full dataset and expose cleaned row counts for animation
- trigger data transformation animation automatically on recommendation with typewriter effect and progress bars for each step
- add CSS for progress bar and loading dots to mimic a streaming "thinking" feel

## Testing
- ✅ `python -m pytest -q`
- ❌ `npm install` (No matching version found for react-chartjs-2@^5.3.1)
- ❌ `CI=true npm test -- --watchAll=false` (react-scripts not found)

