### PR TITLE
fix: restore react-router-dom and expose backend app

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,7 @@ from sklearn.pipeline import Pipeline
 load_dotenv()
 
 app = FastAPI()
+__all__ = ["app"]
 origins = [
     "http://localhost:3000",
 ]
@@ -341,4 +342,9 @@ def calculate_spoilage_risk(avg_temp, humidity, chance_of_rain, month, category)
         risk += 2
 
     return risk
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,13 +12,13 @@
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
-        "react": "^19.1.1",
-        "react-dom": "^19.1.1",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4",
         "chart.js": "^4.4.1",
-        "react-chartjs-2": "^5.3.1",
-        "react-router-dom": "6.22.3"
+        "react-chartjs-2": "^5.3.0",
+        "react-router-dom": "^6.22.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -12715,9 +12715,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
-      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdbDaYmcH6cUA0x7XueGXZijCQUADR5lj6D0UE12HYR0ruOiKu3QyR5I6E0KZzPBtwC2pPPc3Z8QVxunfQ==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12838,14 +12838,14 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
-      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6NC+sQw3clgh4JeX1HAE/vvFN3BZL7XwjZibx7kzPEKDG0ABUAnq8CDGD+8gdBhYgeEMKM+L67vlEiCEB1pQ4g==",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "^19.1.1"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-error-overlay": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,13 +7,13 @@
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4",
     "chart.js": "^4.4.1",
-    "react-chartjs-2": "^5.3.1",
-    "react-router-dom": "6.22.3"
+    "react-chartjs-2": "^5.3.0",
+    "react-router-dom": "^6.22.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/Home.js
+++ b/frontend/src/Home.js
@@ -146,7 +146,6 @@ function Home() {
 
   useEffect(() => {
     fetchGlobalWaste();
-    fetchStoreStats(city);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure `react-router-dom` dependency with React 18
- remove city fetch from initial effect to satisfy hook linting
- expose FastAPI `app` and add a `uvicorn` runner for easier startup

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/scheduler)*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*
- `pytest`
