### PR TITLE
Centralize API URL configuration and update CORS

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -21,7 +21,7 @@ app = FastAPI()
 __all__ = ["app"]
 origins = [
     "http://localhost:3000",
-    "https://smartinvo-e0gv.onrender.com/",
+    "https://smartinvo-e0gv.onrender.com",
 ]
 
 app.add_middleware(

--- a/frontend/src/GlobalWasteSteps.js
+++ b/frontend/src/GlobalWasteSteps.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 
-const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000";
+import { API_URL } from "./config";
 
 const Typewriter = ({ text }) => {
   const [display, setDisplay] = useState("");

--- a/frontend/src/Home.js
+++ b/frontend/src/Home.js
@@ -11,6 +11,7 @@ import {
   Legend,
 } from "chart.js";
 import GlobalWasteSteps from "./GlobalWasteSteps";
+import { API_URL } from "./config";
 
 ChartJS.register(
   CategoryScale,
@@ -21,8 +22,6 @@ ChartJS.register(
   Legend
 );
 ChartJS.defaults.color = "#FFFFFF";
-
-const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000";
 
 function Home() {
   const [item, setItem] = useState("");

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,1 @@
+export const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000";


### PR DESCRIPTION
## Summary
- centralize frontend API base URL in a shared config
- update components to import API URL
- adjust backend CORS origin to match deployed frontend

## Testing
- `pytest`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f3149b074832fb9d7e2f36fe8cb78