### PR TITLE
Centralize API URL configuration and update CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,18 @@
 
 SmartInvo consists of a FastAPI backend and a React frontend.
 
+## Configuration
+
+The backend optionally uses the WeatherAPI service for more accurate
+spoilage predictions. Supply an API key via the `WEATHER_API_KEY`
+environment variable to enable this feature:
+
+```
+export WEATHER_API_KEY=your_key_here
+```
+
+If no key is provided or the weather service is unreachable, the app
+falls back to static defaults so inventory recommendations continue to
+work.
+
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,7 +21,7 @@ app = FastAPI()
 __all__ = ["app"]
 origins = [
     "http://localhost:3000",
-    "https://smartinvo-e0gv.onrender.com/",
+    "https://smartinvo-e0gv.onrender.com",
 ]
 
 app.add_middleware(

--- a/backend/weather.py
+++ b/backend/weather.py
@@ -1,27 +1,47 @@
-import requests
 import os
+import requests
 
 API_KEY = os.getenv("WEATHER_API_KEY")
 
-def get_weather(city):
-    url = f"http://api.weatherapi.com/v1/forecast.json?key=95b3d3f77fb242a287470246253107&q={city}&days=3&aqi=no&alerts=yes"
-    response = requests.get(url)
-    data = response.json()
+
+def get_weather(city: str):
+    """Fetch weather forecast data for a city.
+
+    If the external API is unreachable or an API key is missing, return a
+    minimal structure so the app can continue operating without weather data.
+    """
+
+    if not API_KEY:
+        return {"location": city, "country": "", "forecast": []}
+
+    url = (
+        "https://api.weatherapi.com/v1/forecast.json?"
+        f"key={API_KEY}&q={city}&days=3&aqi=no&alerts=yes"
+    )
+
+    try:
+        response = requests.get(url, timeout=5)
+        response.raise_for_status()
+        data = response.json()
+    except (requests.RequestException, ValueError):
+        return {"location": city, "country": "", "forecast": []}
 
     forecast_data = []
-    for day in data["forecast"]["forecastday"]:
-        forecast_data.append({
-            "date": day["date"],
-            "avg_temp_c": day["day"]["avgtemp_c"],
-            "max_temp_c": day["day"]["maxtemp_c"],
-            "min_temp_c": day["day"]["mintemp_c"],
-            "chance_of_rain": day["day"]["daily_chance_of_rain"],
-            "condition": day["day"]["condition"]["text"],
-            "avg_humidity": day["day"].get("avghumidity", 0)
-        })
+    for day in data.get("forecast", {}).get("forecastday", []):
+        forecast_data.append(
+            {
+                "date": day["date"],
+                "avg_temp_c": day["day"]["avgtemp_c"],
+                "max_temp_c": day["day"]["maxtemp_c"],
+                "min_temp_c": day["day"]["mintemp_c"],
+                "chance_of_rain": day["day"]["daily_chance_of_rain"],
+                "condition": day["day"]["condition"]["text"],
+                "avg_humidity": day["day"].get("avghumidity", 0),
+            }
+        )
 
     return {
-        "location": data["location"]["name"],
-        "country": data["location"]["country"],
-        "forecast": forecast_data
+        "location": data.get("location", {}).get("name", city),
+        "country": data.get("location", {}).get("country", ""),
+        "forecast": forecast_data,
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
       "last 1 safari version"
     ]
   },
-  "homepage": "https://github.com/SyedSharuk16/smartinvo",
+  "homepage": ".",
   "devDependencies": {
     "gh-pages": "^6.3.0"
   }

--- a/frontend/src/GlobalWasteSteps.js
+++ b/frontend/src/GlobalWasteSteps.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 
-const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000";
+import { API_URL } from "./config";
 
 const Typewriter = ({ text }) => {
   const [display, setDisplay] = useState("");

--- a/frontend/src/Home.js
+++ b/frontend/src/Home.js
@@ -11,6 +11,7 @@ import {
   Legend,
 } from "chart.js";
 import GlobalWasteSteps from "./GlobalWasteSteps";
+import { API_URL } from "./config";
 
 ChartJS.register(
   CategoryScale,
@@ -21,8 +22,6 @@ ChartJS.register(
   Legend
 );
 ChartJS.defaults.color = "#FFFFFF";
-
-const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000";
 
 function Home() {
   const [item, setItem] = useState("");

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,1 @@
+export const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000";


### PR DESCRIPTION
## Summary
- centralize frontend API base URL in a shared config
- update components to import API URL
- adjust backend CORS origin to match deployed frontend
- use a relative homepage so React assets load correctly in production
- return empty forecast when WeatherAPI is unreachable or misconfigured
- document optional WEATHER_API_KEY setting

## Testing
- `pytest`
- `CI=true npm test`
