### PR TITLE
chore: update weather API key and dynamic city parameter

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Query
 from pydantic import BaseModel
 from datetime import datetime
 import pandas as pd
@@ -170,7 +170,8 @@ def read_root():
     return {"message": "SmartInventory backend is running "}
 
 @app.get("/weather")
-def fetch_weather(city: str = "Singapore"):
+def fetch_weather(city: str = Query(..., description="City to fetch weather for")):
+    """Return weather data for the requested city."""
     data = get_weather(city)
     return data
 

--- a/backend/weather.py
+++ b/backend/weather.py
@@ -1,7 +1,8 @@
 import os
 import requests
 
-API_KEY = os.getenv("WEATHER_API_KEY")
+# Default to the provided key if the environment variable is absent
+API_KEY = os.getenv("WEATHER_API_KEY", "4831a907bdd447a98aa155214251508")
 
 
 def get_weather(city: str):


### PR DESCRIPTION
## Summary
- default weather API key to new value if env var missing
- require `city` query param on `/weather` endpoint for dynamic forecasts

## Testing
- `pytest -q`

