### PR TITLE
Add homepage slogan and usage steps

### DIFF
--- a/frontend/src/About.js
+++ b/frontend/src/About.js
@@ -39,6 +39,11 @@ function About() {
             environmental signals to give proactive guidance that keeps food
             fresher for longer.
           </p>
+          <p>
+            To use the app, enter an item with its category, city, and arrival
+            date, then click "Get Recommendation" to see predicted spoilage and
+            guidance on managing your stock.
+          </p>
         </div>
       </div>
     </div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,7 +13,7 @@ function App() {
         </button>
         <button onClick={() => setPage("about")}>About</button>
       </nav>
-      {page === "about" ? <About /> : <Home />}
+      {page === "about" ? <About /> : <Home onLearnMore={() => setPage("about")} />}
     </div>
   );
 }

--- a/frontend/src/Home.js
+++ b/frontend/src/Home.js
@@ -23,7 +23,7 @@ ChartJS.register(
 );
 ChartJS.defaults.color = "#FFFFFF";
 
-function Home() {
+function Home({ onLearnMore }) {
   const [item, setItem] = useState("");
   const [category, setCategory] = useState("vegetable");
   const [city, setCity] = useState("Singapore");
@@ -168,6 +168,20 @@ function Home() {
         >
           Smart Inventory Spoilage Predictor
         </h1>
+        <p className="fade-in">
+          predict items expiring soon in your store
+        </p>
+        <p className="fade-in">
+          <a
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              onLearnMore && onLearnMore();
+            }}
+          >
+            click here to learn how to use it
+          </a>
+        </p>
 
       <div className="card">
         <h2>Lookup Shelf Life</h2>


### PR DESCRIPTION
## Summary
- highlight app purpose with a new slogan and learn-how link on the home page
- wire home link to navigate to About section
- expand About page with paragraph describing usage steps

## Testing
- `npm test -- --watchAll=false`
- `pytest -q`

