### PR TITLE
Fix weather API endpoint and key handling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -179,13 +179,21 @@ def fetch_weather(city: str = Query(..., description="City to fetch weather for"
 def recommend_inventory(item: InventoryItem):
     # Fetching weather data
     weather_data = get_weather(item.city)
-    forecast_days = weather_data.get('forecast', [])
-    temps = [day['avg_temp_c'] for day in forecast_days]
-    humidities = [day.get('avg_humidity', 0) for day in forecast_days]
-    rains = [day.get('chance_of_rain', 0) for day in forecast_days]
+    forecast_days = weather_data.get("forecast", [])
+    temps = [day["avg_temp_c"] for day in forecast_days]
+    humidities = [day.get("avg_humidity", 0) for day in forecast_days]
+    rains = [day.get("chance_of_rain", 0) for day in forecast_days]
     avg_temp = sum(temps) / len(temps) if temps else 0
     avg_humidity = sum(humidities) / len(humidities) if humidities else 0
     avg_rain = sum(rains) / len(rains) if rains else 0
+
+    if forecast_days:
+        explanation = (
+            f"Due to current conditions: Temp {avg_temp:.1f}°C, "
+            f"Humidity {avg_humidity:.1f}%, Rain chance {avg_rain}%."
+        )
+    else:
+        explanation = "Weather data unavailable; using default assumptions."
 
     # Calculating days in stock
     arrival = datetime.strptime(item.arrival_date, '%Y-%m-%d')
@@ -241,9 +249,6 @@ def recommend_inventory(item: InventoryItem):
     else:
         advice = f"✅ Low spoilage risk for {item.item}. Safe to stock normally. Estimated remaining shelf life: {remaining_days} days."
 
-    # Extra explanation about weather effect
-    explanation = f"Due to current conditions: Temp {avg_temp:.1f}°C, Humidity {avg_humidity:.1f}%, Rain chance {avg_rain}%."
-
     return {
         "recommendation": advice,
         "risk_score": float(risk_factor * 10),  # Return as 0–10 scale for consistency
@@ -251,7 +256,7 @@ def recommend_inventory(item: InventoryItem):
         "days_in_stock": days_in_stock,
         "avg_shelf_life": avg_life,
         "adjusted_shelf_life": adjusted_shelf_life,
-        "weather_explanation": explanation
+        "weather_explanation": explanation,
     }
 
 

--- a/backend/weather.py
+++ b/backend/weather.py
@@ -1,37 +1,63 @@
 import os
 import requests
 
-API_KEY = os.getenv("WEATHER_API_KEY")
-
 
 def get_weather(city: str):
+    """Fetch a three-day weather forecast for ``city``.
 
-    if not API_KEY:
-        return {"location": city, "country": "", "forecast": []}
+    Returns a dictionary containing the resolved location name, country and a
+    list of per-day forecast details. Each day's entry may omit values if the
+    upstream API does not provide them. If the API key is missing or the
+    request fails, the returned object will include an ``error`` field so the
+    caller can display a helpful message.
+    """
 
-    url = (
-        "https://api.weatherapi.com/v1/fo   recast.json?"
-        f"key=4831a907bdd447a98aa155214251508&q={city}&days=3&aqi=no&alerts=yes"
-    )
+    api_key = os.getenv("WEATHER_API_KEY")
+    if not api_key:
+        # Surface the missing key to callers so they can display an
+        # informative message rather than silently showing empty data.
+        return {
+            "location": city,
+            "country": "",
+            "forecast": [],
+            "error": "missing-api-key",
+        }
+
+    url = "https://api.weatherapi.com/v1/forecast.json"
+    params = {
+        "key": api_key,
+        "q": city,
+        "days": 3,
+        "aqi": "no",
+        "alerts": "yes",
+    }
 
     try:
-        response = requests.get(url, timeout=5)
+        response = requests.get(url, params=params, timeout=5)
         response.raise_for_status()
         data = response.json()
     except (requests.RequestException, ValueError):
-        return {"location": city, "country": "", "forecast": []}
+        # Network errors or unexpected payloads should also be reported
+        # back to the caller so the frontend can react accordingly.
+        return {
+            "location": city,
+            "country": "",
+            "forecast": [],
+            "error": "unavailable",
+        }
 
     forecast_data = []
     for day in data.get("forecast", {}).get("forecastday", []):
+        day_info = day.get("day", {})
         forecast_data.append(
             {
-                "date": day["date"],
-                "avg_temp_c": day["day"]["avgtemp_c"],
-                "max_temp_c": day["day"]["maxtemp_c"],
-                "min_temp_c": day["day"]["mintemp_c"],
-                "chance_of_rain": day["day"]["daily_chance_of_rain"],
-                "condition": day["day"]["condition"]["text"],
-                "avg_humidity": day["day"].get("avghumidity", 0),
+                "date": day.get("date"),
+                "avg_temp_c": day_info.get("avgtemp_c"),
+                "max_temp_c": day_info.get("maxtemp_c"),
+                "min_temp_c": day_info.get("mintemp_c"),
+                "chance_of_rain": day_info.get("daily_chance_of_rain"),
+                "condition": day_info.get("condition", {}).get("text"),
+                "avg_humidity": day_info.get("avghumidity"),
             }
         )
 


### PR DESCRIPTION
## Summary
- Fetch weather API key at runtime and document forecast helper
- Guard against missing forecast fields by using dictionary get lookups
- Return informative error codes when weather API is unavailable and explain missing data to callers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6b26fe9d0832f8218fbbd39ababb0