### PR TITLE
Expose predicted and historical waste items

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ it involves large collection of data and machine learning algoriths to predict t
 
 The app is backboned by python using gradientboostregressors for training model and exhibiting it via react using cross origin resource sharing.
 
+## Model insights
+
+The `/model_info` API now surfaces both the model's top predicted waste items and the commodities with the highest historical losses, helping users verify findings like the high spoilage risk of watermelons.
+

--- a/frontend/src/Home.js
+++ b/frontend/src/Home.js
@@ -383,6 +383,16 @@ function Home({ onLearnMore }) {
           </p>
           <p>{modelInfo.details}</p>
           {modelInfo.conclusion && <p><em>{modelInfo.conclusion}</em></p>}
+          {modelInfo.top_items_predicted && (
+            <p>
+              <strong>Predicted top wastes:</strong> {modelInfo.top_items_predicted.join(", ")}
+            </p>
+          )}
+          {modelInfo.top_items_actual && (
+            <p>
+              <strong>Highest historical wastes:</strong> {modelInfo.top_items_actual.join(", ")}
+            </p>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Surface both predicted and historically highest wasted commodities in the global model
- Show these model insights in the frontend UI
- Document model insight endpoint in README

## Testing
- `pytest`
- `CI=true npm test` *(fails: react-scripts not found after npm install error 403 for @lottiefiles/dotlottie-react)*

